### PR TITLE
Use JSON local index as index for the locals in source map

### DIFF
--- a/src/Parsers/ParseUtils.ts
+++ b/src/Parsers/ParseUtils.ts
@@ -173,8 +173,8 @@ export function getFunctionInfos(input: String): FunctionInfo[] {
         // primitive functions are handled seperately
         if(index >= firstNonPrimiveFunc){
             let locals: VariableInfo[] = [];
-            func.locals.forEach((local: string, index: number) => {
-                locals.push({index: index, name: local, type: 'undefined', mutable: true, value: ''});
+            func.locals.forEach((local: any) => {
+                locals.push({ index: local.idx, name: local.name, type: 'undefined', mutable: true, value: '' });
             });
             const typeIdx = metadata.get(index);
             if(typeIdx === undefined){

--- a/src/State/AllState.ts
+++ b/src/State/AllState.ts
@@ -155,9 +155,10 @@ export class WasmState {
         }
 
         const nrArgs = this.sourceMap.typeInfos.get(func.type)!.parameters.length;
-        const fp = frame.sp + 1 + nrArgs;
-        return func.locals.map((local, idx) => {
-            const sv = stack[fp + idx];
+        const fp = frame.sp + 1;
+        const locals = func.locals.filter(l => l.index >= nrArgs);
+        return locals.map((local) => {
+            const sv = stack[fp + local.index];
             return { index: local.index, name: local.name, type: local.type, mutable: local.mutable, value: `${sv.value}` };
         });
     }


### PR DESCRIPTION
Now that the wat2wasm got changed to print a JSON that includes per local its index ([commit](https://github.com/TOPLLab/wabt/commit/89d092baf7581caa0908a18ac86377929443a952)), we use this information to keep track of the index of each local in the source mapping. This way we can properly distinguish when a local is an argument or a local declared within a function. This lets us fix issue https://github.com/TOPLLab/WARDuino-VSCode/issues/114 and issue https://github.com/TOPLLab/WARDuino-VSCode/issues/106

If accepted this PR will only be merged, once I update the submodule to use the correct version of the WABT.

