### PR TITLE
display the name of the argument in de gui if applicable

### DIFF
--- a/src/State/AllState.ts
+++ b/src/State/AllState.ts
@@ -138,7 +138,10 @@ export class WasmState {
         }
         const argStartIndex = frame.sp + 1;
         const args = this.state.stack.slice(argStartIndex, argStartIndex + argsAmount).map((sv, argIndex) => {
-            return { index: sv.idx, name: `arg${argIndex}`, type: sv.type, mutable: true, value: `${sv.value}` };
+            const nameArg = func.locals.find(loc => {
+                return loc.index === argIndex;
+            })?.name || `arg${argIndex}`;
+            return { index: sv.idx, name: nameArg, type: sv.type, mutable: true, value: `${sv.value}` };
         });
         return args;
     }


### PR DESCRIPTION
Before this commit, the argument values would appear in the `VARIABLES` view of the plugin as `arg1`, `arg2`, etc. Now we use the name of the argument only if possible. If the argument has no name we fallback to the default name `argi` where `i` is the number of the argument.